### PR TITLE
Docs

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -82,6 +82,7 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
+    defaultModelRendering: "model",
     layout: "StandaloneLayout"
   })
  

--- a/pages/guides.md
+++ b/pages/guides.md
@@ -1,0 +1,29 @@
+
+
+# Zentail Open API Workflow Guides
+
+This page outlines some common workflows which can be implemented easily using Zentails Open API.
+
+If you have suggestions for other docs or workflows please reach out to us at [support@zentail.com](mailto:support@zentail.com).
+
+## API Documentation
+
+You can view the full spec of the Zentail Open API at [https://developer.zentail.com/](https://developer.zentail.com/).
+
+## API Basics
+
+1. [Getting an API Token](https://help.zentail.com/open-api/generate-api-token) - You'll need a token to be able to make requests
+1. [Throttle Limits](throttle.html) - Describes the throttle limits for using the Open API
+1. [Timestamp Format](timestamps.html) - An explanation of the expected timestamp format
+1. [Paging](paging.html) - An explanation of how to get multiple pages of data from our API
+
+## Common Operations
+
+1. [Managing Product Data with Reports](https://help.zentail.com/open-api/using-the-reports-endpoint)
+1. [Getting Updates on Sales Orders](lastupdatets.html)
+
+## Common Integration Types
+
+1. [Shipping Software Integration](shipping.html)
+1. [Inventory Management Software Integration](inventory.html)
+1. [Third Party Logistics Provider (3PL) Integration](threepl.html)

--- a/pages/inventory.md
+++ b/pages/inventory.md
@@ -4,28 +4,28 @@
 
 This guide will explain the necessary steps to correctly implement a successful inventory management software solution into Zentail.
 
-Here is a basic outline of what we need to do:
+Here is a basic outline of what Zentail need to do:
 
-1. Obtain an API Token
-1. Figure out your warehouse ID
-1. Update inventory levels in Zentail
-1. Reserve inventory for Orders in Zentail
+1. [Obtain an API Token](https://help.zentail.com/open-api/generate-api-token)
+1. [Find your warehouse ID](#find-your-warehouse-id)
+1. [Update inventory levels in Zentail](#updating-inventory-levels)
+1. [Reserve inventory for Orders in Zentail](#reserve-inventory-for-orders-in-zentail)
 
 ## Obtaining an API Token
 
 To make calls to the Zentail API, you will first need to acquire a token. A separate token will be required for each Zentail account that you wish to integrate with. 
 
-To acquire a token, log in to the Zentail account you want to connect to and go to [https://www.zentail.com/user/settings](https://www.zentail.com/user/settings). 
+To acquire a token, log in to the Zentail account you want to connect to and go to [account settings](https://www.zentail.com/user/settings). 
 Under the "API Access" Tab, simply click the button labeled "Generate New Token". Enter an email address and click "Generate". This email address will be used only 
 to communicate upcoming (and potentially breaking) changes to the API, so please ensure it is a valid email.
 
 
-## Figure out your Warehouse ID
+## Find your Warehouse ID
 
 An important thing to keep in mind is that Zentail supports multiple warehouses, your integration may not be the provider for all warehouses. 
 This means you need to take steps to ensure that you only process orders and line items that have been routed to warehouses you are assigned to manage.
 
-To find the warehouse ID we will use the [GET /warehouses](https://developer.zentail.com/#/Warehouse/get_warehouses) endpoint.
+To find the warehouse ID use [GET /warehouses](https://developer.zentail.com/#/Warehouse/get_warehouses) endpoint.
 
 ```
 curl -X GET "https://api.zentail.com/v1/warehouses" -H "accept: application/json" -H "AUTHORIZATION: your_api_token"
@@ -55,7 +55,7 @@ Making the above call will result in something like this:
 }
 ```
 
-It is up to you to figure out how to tell which of these warehouses you are responsible for, but you can extract the correct IDs from this call. If the field `canUpdateInventory` is false, that means that warehouse is already managed by a native inventory integration and you will not be able to modify inventory levels for that warehouse.
+The receiver needs to distinguish which of these warehouses you are responsible for, but the correct IDs can be found in this call. If the field `canUpdateInventory` is false, that means that warehouse is already managed by a native inventory integration and you will not be able to modify inventory levels for that warehouse.
 
 ## Updating Inventory Levels
 
@@ -65,27 +65,29 @@ There are several options when it comes to updating inventory levels in Zentail.
 
 Inventory updates can be submitted using the [POST /inventory](https://developer.zentail.com/#/Inventory/post_inventory) endpoint, providing up to 50 updates per call. They can also be provided using the [POST /reports](https://developer.zentail.com/#/Report/post_report) endpoint (more about that [here](https://help.zentail.com/open-api/using-the-reports-endpoint)). 
 
-Since time is always of the essence when it comes to inventory updates, we recommend using the inventory API endpoint if scale permits. It is built to ingest inventory updates very quickly and easily but really has no frills as a result. If you need to upload thousands of levels all at once and the throttling becomes too heavy, at that point you may want to consider using the reports endpoint since it is much less constrained on the volume you can submit. Note however that the reports endpoint does have a latency tradeoff since there is a delay before our system picks the report up for processing and the report processing engine is a tiny bit slower than the inventory API.
+The inventory endpoint is the lowest latency way to perform inventory updates. It is built to ingest inventory updates very quickly.
+
+If throttling becomes too heavy consider using the reports endpoint since it is less constrained on the volume you can submit. Note however that the reports endpoint does have a latency trade-off since there is a delay before the system will process them.
 
 ### Inventory Management Fields
 
-All inventory is managed on a per-warehouse basis and aggregated automatically in Zentail. We offer multiple different form factors for providing inventory levels, which one you use is based soley on how your system operates.
+All inventory is managed on a per-warehouse basis and aggregated automatically in Zentail. Zentail offer multiple different form factors for providing inventory levels, which one you use is based soley on how your system operates.
 
 | field | description |
 | ---- | ---- |
 | quantity | Sending this field will set the absolute quantity value in Zentail. If you send 10, that product now has 10 in that warehouse. |
-| delta_quantity | Sending this field will modify the current quantity in Zentail by the given amount. If we have 10 in that warehouse and you send 5, now it has 15. |
-| onhand_quantity | Sending this field will set the absolute quantity value in Zentail *after subtracting any PENDING or PENDING_PAYMENT order quantities*. If you send 10 and there are 9 units reserved against that warehouse, we will set our quantity to 1 |
+| delta_quantity | Sending this field will modify the current quantity in Zentail by the given amount. If Zentail have 10 in that warehouse and you send 5, now it has 15. |
+| onhand_quantity | Sending this field will set the absolute quantity value in Zentail *after subtracting any PENDING or PENDING_PAYMENT order quantities*. If you send 10 and there are 9 units reserved against that warehouse, Zentail will set our quantity to 1 |
 
 *Please note that it only makes sense to include **ONE** of the above fields per sku/warehouse combination. Since they all modify the same core field in Zentail they will just compete with each other. The inventory API will also require that only one is provided per-item*
 
 ### Valid As Of Timestamp
 
-Another benefit of using the inventory API over reports is the ability to provide a `validAsOf` timestamp. This is sent at the call level so it is applied to all entries in that request. You can use the `validAsOf` timestamp to indicate to us when the inventory level was computed or when it is accurate as of. We will use that timestamp and modify the level you send us by any pending orders routed to that warehouse between that time and the time we ingest the inventory levels. This allows Zentail to be extra confident in our inventory levels and further minimize the risk of overselling.
+Another benefit of using the inventory API over reports is the ability to provide a `validAsOf` timestamp. This is sent at the call level so it is applied to all entries in that request. It is possible to use the `validAsOf` timestamp to indicate to Zentail when the inventory level was computed or when it is accurate as of. Zentail will use that timestamp and modify the level you send by any pending orders routed to that warehouse between that time and the time Zentail ingest the inventory levels. This allows Zentail to be extra confident in our inventory levels and further minimize the risk of overselling.
 
 ### Using Reports API
 
-If you use the reports API instead of the inventory API, you will need to use the following type of fields to provide inventory levels. They all follow a consistent format of `wp_<warehouse_id>_<field_name>` so for instance if your warehouse ID is 4 you can use the following headers:
+If you use the reports API instead of the inventory API, you will need to use the following type of fields to provide inventory levels. They all follow a consistent format of `wp_<warehouse_id>_<field_name>` so for instance if your warehouse ID is 4 use the following headers:
 
 ```
 wp_4_quantity
@@ -116,17 +118,16 @@ curl -X POST "https://api.zentail.com/v1/inventory" \
 
 ## Reserve Inventory for Orders in Zentail
 
-In order to minimize the risk of overselling, Zentail will automatically update our internal inventory levels when new orders come in. This occurs even before the order is paid on the sales channel (we will hold the inventory for up to 30 days if the order is not paid, then release it back to stock). To implement the ideal workflow with Zentail you should regularly poll for sales orders in the `PENDING` or `PENDING_PAYMENT` status and mark that inventory as on hold. When the order is fulfilled, fulfill it from that on-hold inventory so the accounting all works out. Also, if an order is cancelled pre-fulfillment, Zentail customers can decide to release the reserved inventory for that order back into sellable inventory.
+In order to minimize the risk of overselling, Zentail will automatically update our internal inventory levels when new orders come in. This occurs even before the order is paid on the sales channel (we will hold the inventory for up to 30 days if the order is not paid, then release it back to stock). To implement the ideal workflow with Zentail, regularly poll for sales orders in the `PENDING` or `PENDING_PAYMENT` status and mark that inventory as on hold. When the order is fulfilled, fulfill it from that on-hold inventory so the inventory is correctly tracked. Also, if an order is cancelled pre-fulfillment, Zentail customers can decide to release the reserved inventory for that order back into sellable inventory.
 
-The basic principle here is to keep track of the last time you asked for updates and provide the `lastUpdatedTs` and `status` filters to our [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) endpoint. Most importantly, we will want to provide the `warehouseId` filter. 
+The basic principle here is to keep track of the last time you asked for updates and provide the `lastUpdatedTs` and `status` filters to our [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) endpoint. Most importantly, a `warehouseId` should be provided.
 
-If the `warehouseId` filter is provided, we will only return quantity and line items that have been routed to the given warehouse ID. This ensures that you only process items that 
+If the `warehouseId` filter is provided, Zentail will only return quantity and line items that have been routed to the given warehouse ID. This ensures that you only process items that 
 your integration is responsible for. If you omit the `warehouseId` filter because you wish to see all of the data on an order, please be sure to reference the `routing_info` section and only allow shipment of line items which have non-zero quantity assigned to your warehouse ID.
 
-There are a few methods for filtering the orders, the most useful will be `lastUpdatedTs`. If provided, that timestamp will provide a marker and only orders that have had some kind of 
-modification after that timestamp will be included in the response. This is the Zentail recommended way to query for orders, but we also provide filters for order status and for order creation time.
+There are a few methods for filtering the orders, the most useful will be `lastUpdatedTs`. If provided, only orders that have been updated after the given timestamp will be included in the response. This is the recommended way to query for orders, but Zentail also provide filters for order status and for order creation time.
 
-Lets look at a sample call to the api:
+Lets look at a sample call to the sales order endpoint:
 
 ```
 curl -X GET "https://api.zentail.com/v1/salesOrder?warehouseId=4&lastUpdatedTs=2018-03-01T16:15:46.740Z&status=PENDING_PAYMENT,PENDING,CANCELLED" \
@@ -135,7 +136,7 @@ curl -X GET "https://api.zentail.com/v1/salesOrder?warehouseId=4&lastUpdatedTs=2
 
 ```
 
-You can see in that call we provide 3 filters:
+Notice in that call Zentail provide 3 filters:
 
 | Field | Value | Description |
 | ---- | ---- | ---- |
@@ -154,7 +155,7 @@ At the root of the order, there is some important information:
 
 | Field | Recommended Use |
 | ---- | ---- |
-| orderNumber | This is the Zentail order number, use this in all future reference to this order |
+| orderNumber | This is the Zentail order number, use this as the unique identifier for this order for this particular account |
 | status | An indicator of the overall status of the order, `PENDING_PAYMENT` and `PENDING` orders should trigger the inventory to be reserved. For a full list of statuses [see the docs](https://developer.zentail.com/#/definitions/SOResponseData) |
 
 
@@ -174,7 +175,7 @@ If you now examine the `products` field of the order response, there is more imp
 | shippedQuantity | This is the quantity that has already been shipped. **Note:** This quantity may reflected shipped orders from other warehouses so its not necessarily reliable if the `warehouseId` filter is used. | 
 
 <br /><br />
-There are a bunch of other fields available here, see the docs for more info on those. You should be able to compile the data from our API to understand what inventory to reserve and what to release.
+There are a bunch of other fields available here, see the docs for more info on those.
 	
 
 See the guide on [tracking order updates](pages/lastupdatets.html) for more examples of getting order updates.

--- a/pages/inventory.md
+++ b/pages/inventory.md
@@ -168,14 +168,14 @@ If you now examine the `products` field of the order response, there is more imp
 | ---- | ---- |
 | lineItemId | An identifier unique to this order which represents this specific line item on the order. | 
 | status | Similar to status above, this is a more granular indication of the status of this individual line item. | 
-| requestedSku | This is the SKU requested by the sales channel, this may be a SKU that doesnt exist in Zentail. It may also not be the SKU that Zentail has decided should be used to fulfill this order. For the sku that should be used for filling the line item, see the `SKU` field. |
-| SKU | This is the SKU that was matched in Zentail and should be fulfilled. It is possible that this field is NULL if the line item does not correspond to a known product in Zentail. In that case, `requestedSku` should be used as a fallback. | 
-| quantity | This is the quantity that was requested to fulfill this line item. If a warehouse ID filter is provided, it will be only the quantity routed to that warehouse. | 
+| requestedSku | This is the SKU requested by the sales channel, this may be a SKU that doesn't exist in Zentail. It also may not match the SKU that Zentail has chosen to fulfill this order (see the SKU field for this). |
+| SKU | This is the SKU Zentail chose to fulfill this line item. It is possible that this field is NULL if the line item does not correspond to a known product in Zentail. In that case, `requestedSku` should be used as a fallback. | 
+| quantity | This is the quantity that was requested to fulfill this line item. If a warehouse ID filter is provided, this filed will only contain the quantity routed to that warehouse. | 
 | cancelQuantity | This is the quantity that has been cancelled, this should be deducted from the quantity field above when determining how many items still need to be shipped. |
-| shippedQuantity | This is the quantity that has already been shipped. **Note:** This quantity may reflected shipped orders from other warehouses so its not necessarily reliable if the `warehouseId` filter is used. | 
+| shippedQuantity | This is the quantity that has already been shipped. **Note:** This quantity may reflect shipped orders from other warehouses so its not necessarily reliable if the `warehouseId` filter is used. | 
 
 <br /><br />
-There are a bunch of other fields available here, see the docs for more info on those.
+There are a multitude of other fields available here (see the docs for more info on those), which you can use to understand what inventory to reserve and what to release.
 	
 
 See the guide on [tracking order updates](pages/lastupdatets.html) for more examples of getting order updates.

--- a/pages/inventory.md
+++ b/pages/inventory.md
@@ -1,0 +1,180 @@
+
+
+# Building an Inventory Software Integration with Zentail
+
+This guide will explain the necessary steps to correctly implement a successful inventory management software solution into Zentail.
+
+Here is a basic outline of what we need to do:
+
+1. Obtain an API Token
+1. Figure out your warehouse ID
+1. Update inventory levels in Zentail
+1. Reserve inventory for Orders in Zentail
+
+## Obtaining an API Token
+
+To make calls to the Zentail API, you will first need to acquire a token. A separate token will be required for each Zentail account that you wish to integrate with. 
+
+To acquire a token, log in to the Zentail account you want to connect to and go to [https://www.zentail.com/user/settings](https://www.zentail.com/user/settings). 
+Under the "API Access" Tab, simply click the button labeled "Generate New Token". Enter an email address and click "Generate". This email address will be used only 
+to communicate upcoming (and potentially breaking) changes to the API, so please ensure it is a valid email.
+
+
+## Figure out your Warehouse ID
+
+An important thing to keep in mind is that Zentail supports multiple warehouses, your integration may not be the provider for all warehouses. 
+This means you need to take steps to ensure that you only process orders and line items that have been routed to warehouses you are assigned to manage.
+
+To find the warehouse ID we will use the [GET /warehouses](https://developer.zentail.com/#/Warehouse/get_warehouses) endpoint.
+
+```
+curl -X GET "https://api.zentail.com/v1/warehouses" -H "accept: application/json" -H "AUTHORIZATION: your_api_token"
+```
+
+Making the above call will result in something like this:
+
+```
+{
+    "results": [
+        {
+            "warehouseId": "4",
+            "canUpdateInventory": false,
+            "name": "WAREHOUSE_00000"
+        },
+        {
+            "warehouseId": "69",
+            "canUpdateInventory": true,
+            "name": "WAREHOUSE_00001a112"
+        },
+        {
+            "warehouseId": "70",
+            "canUpdateInventory": false,
+            "name": "fba"
+        }
+    ]
+}
+```
+
+It is up to you to figure out how to tell which of these warehouses you are responsible for, but you can extract the correct IDs from this call. If the field `canUpdateInventory` is false, that means that warehouse is already managed by a native inventory integration and you will not be able to modify inventory levels for that warehouse.
+
+## Updating Inventory Levels
+
+There are several options when it comes to updating inventory levels in Zentail. This section will describe the pros and cons of each method.
+
+### Submission Methods
+
+Inventory updates can be submitted using the [POST /inventory](https://developer.zentail.com/#/Inventory/post_inventory) endpoint, providing up to 50 updates per call. They can also be provided using the [POST /reports](https://developer.zentail.com/#/Report/post_report) endpoint (more about that [here](https://help.zentail.com/open-api/using-the-reports-endpoint)). 
+
+Since time is always of the essence when it comes to inventory updates, we recommend using the inventory API endpoint if scale permits. It is built to ingest inventory updates very quickly and easily but really has no frills as a result. If you need to upload thousands of levels all at once and the throttling becomes too heavy, at that point you may want to consider using the reports endpoint since it is much less constrained on the volume you can submit. Note however that the reports endpoint does have a latency tradeoff since there is a delay before our system picks the report up for processing and the report processing engine is a tiny bit slower than the inventory API.
+
+### Inventory Management Fields
+
+All inventory is managed on a per-warehouse basis and aggregated automatically in Zentail. We offer multiple different form factors for providing inventory levels, which one you use is based soley on how your system operates.
+
+| field | description |
+| ---- | ---- |
+| quantity | Sending this field will set the absolute quantity value in Zentail. If you send 10, that product now has 10 in that warehouse. |
+| delta_quantity | Sending this field will modify the current quantity in Zentail by the given amount. If we have 10 in that warehouse and you send 5, now it has 15. |
+| onhand_quantity | Sending this field will set the absolute quantity value in Zentail *after subtracting any PENDING or PENDING_PAYMENT order quantities*. If you send 10 and there are 9 units reserved against that warehouse, we will set our quantity to 1 |
+
+*Please note that it only makes sense to include **ONE** of the above fields per sku/warehouse combination. Since they all modify the same core field in Zentail they will just compete with each other. The inventory API will also require that only one is provided per-item*
+
+### Valid As Of Timestamp
+
+Another benefit of using the inventory API over reports is the ability to provide a `validAsOf` timestamp. This is sent at the call level so it is applied to all entries in that request. You can use the `validAsOf` timestamp to indicate to us when the inventory level was computed or when it is accurate as of. We will use that timestamp and modify the level you send us by any pending orders routed to that warehouse between that time and the time we ingest the inventory levels. This allows Zentail to be extra confident in our inventory levels and further minimize the risk of overselling.
+
+### Using Reports API
+
+If you use the reports API instead of the inventory API, you will need to use the following type of fields to provide inventory levels. They all follow a consistent format of `wp_<warehouse_id>_<field_name>` so for instance if your warehouse ID is 4 you can use the following headers:
+
+```
+wp_4_quantity
+wp_4_onhand_quantity
+wp_4_delta_quantity
+```
+
+### Example
+
+An example which sets the following levels:
+
+For TESTSKU1, set the total quantity available in warehouse ID 4 to 10.
+For TESTSKU1, set the on hand quantity in warehouse ID 5 to 6.
+For TESTSKU2, subtract 4 from the quantity in warehouse ID 5.
+
+We also provide the optional `binLocation` field.
+
+Since the inventory is provided validAsOf May 5th 2019 and 18:28 UTC, all orders after that time will also be deducted from TESTSKU1 in warehouses 4 and 5.
+
+```
+curl -X POST "https://api.zentail.com/v1/inventory" \
+	-H "accept: application/json" \
+	-H "Content-Type: application/json" \
+	-H "AUTHORIZATION: your_api_token \
+	-d "{ \"products\": [ { \"SKU\": \"TESTSKU1\", \"quantity\": 10, \"binLocation\": \"BIN-1\", \"warehouseId\": 4 }, { \"SKU\": \"TESTSKU1\", \"onhand_quantity\": 6, \"binLocation\": \"BIN-2-1\", \"warehouseId\": 5 }, { \"SKU\": \"TESTSKU2\", \"delta_quantity\": -4, \"binLocation\": \"BIN-2-2\", \"warehouseId\": 5 } ], \"validAsOf\": \"2019-05-08T18:28:45.086Z\"}"
+```
+
+
+## Reserve Inventory for Orders in Zentail
+
+In order to minimize the risk of overselling, Zentail will automatically update our internal inventory levels when new orders come in. This occurs even before the order is paid on the sales channel (we will hold the inventory for up to 30 days if the order is not paid, then release it back to stock). To implement the ideal workflow with Zentail you should regularly poll for sales orders in the `PENDING` or `PENDING_PAYMENT` status and mark that inventory as on hold. When the order is fulfilled, fulfill it from that on-hold inventory so the accounting all works out. Also, if an order is cancelled pre-fulfillment, Zentail customers can decide to release the reserved inventory for that order back into sellable inventory.
+
+The basic principle here is to keep track of the last time you asked for updates and provide the `lastUpdatedTs` and `status` filters to our [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) endpoint. Most importantly, we will want to provide the `warehouseId` filter. 
+
+If the `warehouseId` filter is provided, we will only return quantity and line items that have been routed to the given warehouse ID. This ensures that you only process items that 
+your integration is responsible for. If you omit the `warehouseId` filter because you wish to see all of the data on an order, please be sure to reference the `routing_info` section and only allow shipment of line items which have non-zero quantity assigned to your warehouse ID.
+
+There are a few methods for filtering the orders, the most useful will be `lastUpdatedTs`. If provided, that timestamp will provide a marker and only orders that have had some kind of 
+modification after that timestamp will be included in the response. This is the Zentail recommended way to query for orders, but we also provide filters for order status and for order creation time.
+
+Lets look at a sample call to the api:
+
+```
+curl -X GET "https://api.zentail.com/v1/salesOrder?warehouseId=4&lastUpdatedTs=2018-03-01T16:15:46.740Z&status=PENDING_PAYMENT,PENDING,CANCELLED" \
+	-H "accept: application/json" \
+	-H "AUTHORIZATION: your_api_token"
+
+```
+
+You can see in that call we provide 3 filters:
+
+| Field | Value | Description |
+| ---- | ---- | ---- |
+| warehouseId | 4 | Only provide orders routed to warehouse ID 4 | 
+| lastUpdatedTs | 2018-03-01T16:15:46.740Z | Only provide orders updated after March 1st 2018 | 
+| status | PENDING_PAYMENT,PENDING,CANCELLED | Only return orders that are in the PENDING_PAYMENT, PENDING or CANCELLED status |
+
+We'll just look at some specific points of interest in one of the orders in the response.
+
+
+
+### Order Data
+
+At the root of the order, there is some important information:
+
+
+| Field | Recommended Use |
+| ---- | ---- |
+| orderNumber | This is the Zentail order number, use this in all future reference to this order |
+| status | An indicator of the overall status of the order, `PENDING_PAYMENT` and `PENDING` orders should trigger the inventory to be reserved. For a full list of statuses [see the docs](https://developer.zentail.com/#/definitions/SOResponseData) |
+
+
+<br />
+### Line Items
+
+If you now examine the `products` field of the order response, there is more important information:
+
+| Field | Recommended Use | 
+| ---- | ---- |
+| lineItemId | An identifier unique to this order which represents this specific line item on the order. | 
+| status | Similar to status above, this is a more granular indication of the status of this individual line item. | 
+| requestedSku | This is the SKU requested by the sales channel, this may be a SKU that doesnt exist in Zentail. It may also not be the SKU that Zentail has decided should be used to fulfill this order. For the sku that should be used for filling the line item, see the `SKU` field. |
+| SKU | This is the SKU that was matched in Zentail and should be fulfilled. It is possible that this field is NULL if the line item does not correspond to a known product in Zentail. In that case, `requestedSku` should be used as a fallback. | 
+| quantity | This is the quantity that was requested to fulfill this line item. If a warehouse ID filter is provided, it will be only the quantity routed to that warehouse. | 
+| cancelQuantity | This is the quantity that has been cancelled, this should be deducted from the quantity field above when determining how many items still need to be shipped. |
+| shippedQuantity | This is the quantity that has already been shipped. **Note:** This quantity may reflected shipped orders from other warehouses so its not necessarily reliable if the `warehouseId` filter is used. | 
+
+<br /><br />
+There are a bunch of other fields available here, see the docs for more info on those. You should be able to compile the data from our API to understand what inventory to reserve and what to release.
+	
+
+See the guide on [tracking order updates](pages/lastupdatets.html) for more examples of getting order updates.

--- a/pages/lastupdatets.md
+++ b/pages/lastupdatets.md
@@ -1,0 +1,42 @@
+
+# Tracking Order Updates with the Zentail Open API
+
+This guide will outline how to use the Open API to retrieve new and updated orders from Zentail.
+
+
+## Timestamp-Based
+
+The general process we recommend is to keep a timestamp in your code which keeps track of the last time you requested orders. Sending this timestamp (we generally like to build in a small buffer around 5 minutes) to the [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) endpoint in the `lastUpdatedTs` will retrieve all orders that have been created or modified since the provided timestamp. See [the timestamp guide](/pages/timestamps.html) for more information on formatting and working with timestamps.
+
+Example providing `lastUpdatedTs`:
+
+```
+curl -X GET "https://api.zentail.com/v1/salesOrder?lastUpdatedTs=2019-05-08T17%3A01%3A16.152Z" \
+	-H "accept: application/json" \
+	-H "AUTHORIZATION: <your token here>"
+```
+
+*Note that `lastUpdatedTs` is different from `orderTs`, `orderTs` is the time the order was placed and will not change when it is updated.*
+
+### Other Filters
+
+If there are only certain kinds of orders you are interested in, you can also provide a status filter. The current order statuses we provide are:
+
+```
+PENDING_PAYMENT, PENDING, SHIPPED, CANCELLED, RETURNED, REFUNDED, RETURN_REQUESTED
+```
+
+For instance, if you are a shipping software you may only care about `PENDING_PAYMENT`, `PENDING` and `CANCELLED` orders. See the following example request which provideds both status and last updated timestamp:
+
+```
+
+curl -X GET "https://api.zentail.com/v1/salesOrder?lastUpdatedTs=2019-05-08T17%3A01%3A16.152Z&status=PENDING_PAYMENT,PENDING,CANCELLED" \
+	-H "accept: application/json" \
+	-H "AUTHORIZATION: <your token here>"
+```
+
+You can consult [our docs](https://developer.zentail.com/#/SalesOrder/get_salesOrder) for the other filters available.
+
+## Paging
+
+Keep in mind that the responses to [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) will be paged, the default page size is 25 but it can be set up to 100. For more info on paging see [the paging guide](/pages/paging.html).

--- a/pages/lastupdatets.md
+++ b/pages/lastupdatets.md
@@ -6,7 +6,7 @@ This guide will outline how to use the Open API to retrieve new and updated orde
 
 ## Timestamp-Based
 
-The general process we recommend is to keep a timestamp in your code which keeps track of the last time you requested orders. Sending this timestamp (we generally like to build in a small buffer around 5 minutes) to the [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) endpoint in the `lastUpdatedTs` will retrieve all orders that have been created or modified since the provided timestamp. See [the timestamp guide](/pages/timestamps.html) for more information on formatting and working with timestamps.
+The recommended process is to keep a timestamp in your code which keeps track of the last time you requested orders. Sending this timestamp (A small buffer of 5 minutes is suggested) to the [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) endpoint in the `lastUpdatedTs` will retrieve all orders that have been created or modified since the provided timestamp. See [the timestamp guide](/pages/timestamps.html) for more information on formatting and working with timestamps.
 
 Example providing `lastUpdatedTs`:
 
@@ -20,7 +20,7 @@ curl -X GET "https://api.zentail.com/v1/salesOrder?lastUpdatedTs=2019-05-08T17%3
 
 ### Other Filters
 
-If there are only certain kinds of orders you are interested in, you can also provide a status filter. The current order statuses we provide are:
+If there are only certain kinds of orders you are interested in, it is also possible to provide a status filter. The current order statuses provided are:
 
 ```
 PENDING_PAYMENT, PENDING, SHIPPED, CANCELLED, RETURNED, REFUNDED, RETURN_REQUESTED

--- a/pages/paging.md
+++ b/pages/paging.md
@@ -1,0 +1,62 @@
+
+# Zentail Open API Page Tokens
+
+This document outlines the use of the paging tokens returned by various parts of the Zentail Open API. Some example calls you might find pagination in include [GET /salesOrder](/#/SalesOrder/get_salesOrder) and [GET /inventory](/#/Inventory/get_inventory).
+
+When our system is trying to return a large number of results in response to an API call, we implement paging to reduce the response time as well as control the resources used in each transaction. For calls that are paged, you should see the `pagination` object on the result specification.
+
+```
+Pagination{
+hasNext*	boolean
+This is true if there is a next page of results.
+
+nextToken*	string($uri)
+Use this to request the next page of results.
+}
+```
+
+Inspection of this object can dictate how you should proceed. The basic logic should go like this:
+
+1. Check the `pagination` object for the key `hasNext`. If it is `false`, there are no more pages and you are at the end of the list. If it's `true`, proceed to step 2.
+2. Take the value of `pagination.nextToken` and make a request to that URL. The value will contain the full URL so do not append it to the request, just send a GET request to that URL.
+3. Repeat step 2 until `hasNext` is `false`
+
+See the following example PHP code which makes calls to our api to list all orders:
+
+```
+function listAllOrdersToken(string $url) {
+    $client = new \GuzzleHttp\Client(["base_uri" => $url]);
+    $response = $client->request("GET", "",  [ 
+        "headers" => ["AUTHORIZATION" => "1e89c5e609fee7182ef8d5cbefe69a2caf7c082329c381b252f08c83aedbf545"]
+    ]);
+    $results = json_decode($response->getBody());
+    foreach($results->results as $order) {
+        yield $order;
+    }
+
+    if($results->pagination->hasNext) {
+        yield from listAllOrdersToken($results->pagination->nextToken);
+    }
+}
+
+function listAllOrdersSince(int $timestamp) {
+    $client = new \GuzzleHttp\Client(["base_uri" => "https://api.zentail.com/"]);
+    $response = $client->request("GET", "/v1/salesOrder?lastUpdatedTs=" . urlencode(date("c", $timestamp)),  [ 
+        "headers" => ["AUTHORIZATION" => "1e89c5e609fee7182ef8d5cbefe69a2caf7c082329c381b252f08c83aedbf545"]
+    ]);
+    $results = json_decode($response->getBody());
+    foreach($results->results as $order) {
+        yield $order;
+    }
+    
+    if($results->pagination->hasNext) {
+        yield from listAllOrdersToken($results->pagination->nextToken);
+    }
+}
+
+foreach(listAllOrdersSince(strtotime("-60 days")) as $order) {
+    echo $order->orderNumber . " -- " . $order->lastUpdatedTs . " \n";
+}
+```
+
+

--- a/pages/paging.md
+++ b/pages/paging.md
@@ -3,7 +3,7 @@
 
 This document outlines the use of the paging tokens returned by various parts of the Zentail Open API. Some example calls you might find pagination in include [GET /salesOrder](/#/SalesOrder/get_salesOrder) and [GET /inventory](/#/Inventory/get_inventory).
 
-When our system is trying to return a large number of results in response to an API call, we implement paging to reduce the response time as well as control the resources used in each transaction. For calls that are paged, you should see the `pagination` object on the result specification.
+The Zentail API uses paging to reduce the response time as well as control the resources used in each transaction. For calls that are paged, you will see the `pagination` object on the result specification.
 
 ```
 Pagination{
@@ -15,7 +15,7 @@ Use this to request the next page of results.
 }
 ```
 
-Inspection of this object can dictate how you should proceed. The basic logic should go like this:
+This object will dictate how to proceed:
 
 1. Check the `pagination` object for the key `hasNext`. If it is `false`, there are no more pages and you are at the end of the list. If it's `true`, proceed to step 2.
 2. Take the value of `pagination.nextToken` and make a request to that URL. The value will contain the full URL so do not append it to the request, just send a GET request to that URL.

--- a/pages/shipping.md
+++ b/pages/shipping.md
@@ -6,10 +6,10 @@ This guide will explain the necessary steps to correctly implement a successful 
 
 Here is a basic outline of what we need to do:
 
-1. Obtain an API Token
-1. Figure out your warehouse ID
-1. Request order data from Zentail
-1. Send back shipment notifications
+1. [Obtain an API Token](https://help.zentail.com/open-api/generate-api-token)
+1. [Find your warehouse ID](#find-your-warehouse-id)
+1. [Request order data from Zentail](#request-order-data)
+1. [Send back shipment notifications](#sending-shipment-notifications)
 
 
 ## Obtaining an API Token
@@ -21,12 +21,12 @@ Under the "API Access" Tab, simply click the button labeled "Generate New Token"
 to communicate upcoming (and potentially breaking) changes to the API, so please ensure it is a valid email.
 
 
-## Figure out your Warehouse ID
+## Find your Warehouse ID
 
 An important thing to keep in mind is that Zentail supports multiple warehouses, your integration may not be the provider for all warehouses. 
 This means you need to take steps to ensure that you only process orders and line items that have been routed to warehouses you are assigned to manage.
 
-To find the warehouse ID we will use the [GET /warehouses](https://developer.zentail.com/#/Warehouse/get_warehouses) endpoint.
+To find the warehouse ID use the [GET /warehouses](https://developer.zentail.com/#/Warehouse/get_warehouses) endpoint.
 
 ```
 curl -X GET "https://api.zentail.com/v1/warehouses" -H "accept: application/json" -H "AUTHORIZATION: your_api_token"
@@ -88,7 +88,7 @@ At the root of the order, there is some important information:
 
 | Field | Recommended Use |
 | ---- | ---- |
-| orderNumber | This is the Zentail order number, use this in all future reference to this order |
+| orderNumber | This is the Zentail order number, use this as the unique identifier for this order for this particular account |
 | status | An indicator of the overall status of the order, `PENDING_PAYMENT` orders generally should not be shipped until they reach `PENDING`. For a full list of statuses [see the docs](https://developer.zentail.com/#/definitions/SOResponseData) |
 | shippingAddress | This is the address that the items in this order should be shipped to, there will only ever be one shipping address per order. | 
 | packages | This represents any packages already created for this order, each package may also contain items that we know are contained in the package. | 

--- a/pages/template.hbs
+++ b/pages/template.hbs
@@ -47,7 +47,11 @@
   <script>hljs.initHighlightingOnLoad();</script>
 </head>
 <body class="swagger-ui">
-  <div class="topbar"><div class="wrapper"><div class="topbar-wrapper"><a href="#" class="link"><span>Zentail Developer Portal</span></a><ul class="links"><li><a href="https://www.zentail.com/user/dashboard">Log In</a></li></ul></div></div></div>
+  <div class="topbar"><div class="wrapper"><div class="topbar-wrapper"><a href="#" class="link"><span>Zentail Developer Portal</span></a><ul class="links">
+    <li><a href="https://developer.zentail.com/">API Specification</a></li>
+    <li><a href="https://developer.zentail.com/pages/guides.html">API Guides</a></li>
+    <li><a href="https://app.zentail.com/user/dashboard">Log In</a></li>
+  </ul></div></div></div>
 
   <div class="swagger-ui wrapper info main-wrapper">
     <section>

--- a/pages/threepl.md
+++ b/pages/threepl.md
@@ -3,11 +3,11 @@
 
 Building a 3PL integration into Zentail is quite easy using our Open API. The basic things you will need to do are as follows:
 
-1. Obtain an API Token
-1. Figure out your warehouse ID
-1. Request order data from Zentail
-1. Send back shipment notifications
-1. Update inventory levels in Zentail
+1. [Obtain an API Token](https://help.zentail.com/open-api/generate-api-token)
+1. [Find your warehouse ID](shipping.html#find-your-warehouse-id)
+1. [Request order data from Zentail](shipping.html#request-order-data)
+1. [Send back shipment notifications](shipping.html#sending-shipment-notifications)
+1. [Update inventory levels in Zentail](inventory.html#updating-inventory-levels)
 
 The way Zentail generally treats 3PL integrations is in 2 parts. One is the shipping integration part and the other is an inventory integration. You can follow these docs which outline the process of implementing each one and that should cover all of the above use cases.
 

--- a/pages/threepl.md
+++ b/pages/threepl.md
@@ -9,7 +9,7 @@ Building a 3PL integration into Zentail is quite easy using our Open API. The ba
 1. [Send back shipment notifications](shipping.html#sending-shipment-notifications)
 1. [Update inventory levels in Zentail](inventory.html#updating-inventory-levels)
 
-The way Zentail generally treats 3PL integrations is in 2 parts. One is the shipping integration part and the other is an inventory integration. You can follow these docs which outline the process of implementing each one and that should cover all of the above use cases.
+Zentail's 3PL integrations generally have two functions -- shipping and inventory management. Here is some guidance on how to implement each:
 
 1. [Shipping Software Integration](shipping.html)
 1. [Inventory Management Software Integration](inventory.html)

--- a/pages/threepl.md
+++ b/pages/threepl.md
@@ -1,0 +1,15 @@
+
+# Building a Third Party Logistics Provider (3PL) Integration with Zentail
+
+Building a 3PL integration into Zentail is quite easy using our Open API. The basic things you will need to do are as follows:
+
+1. Obtain an API Token
+1. Figure out your warehouse ID
+1. Request order data from Zentail
+1. Send back shipment notifications
+1. Update inventory levels in Zentail
+
+The way Zentail generally treats 3PL integrations is in 2 parts. One is the shipping integration part and the other is an inventory integration. You can follow these docs which outline the process of implementing each one and that should cover all of the above use cases.
+
+1. [Shipping Software Integration](shipping.html)
+1. [Inventory Management Software Integration](inventory.html)

--- a/pages/throttle.md
+++ b/pages/throttle.md
@@ -1,0 +1,10 @@
+
+
+# Zentail Open API Throttle Limits
+
+Our current throttle limit implements the common throttling algorithm known as the [leaky bucket](https://en.wikipedia.org/wiki/Leaky_bucket). 
+The bucket empties at a rate of 10 requests per second and allows bursts up to 10 requests. 
+
+Please note, this limit is shared across all incoming requests.
+
+If you exceed the limit you will recieve a 429 response.

--- a/pages/throttle.md
+++ b/pages/throttle.md
@@ -7,4 +7,4 @@ The bucket empties at a rate of 10 requests per second and allows bursts up to 1
 
 Please note, this limit is shared across all incoming requests.
 
-If you exceed the limit you will recieve a 429 response.
+If you exceed the limit you will receive a 429 response.

--- a/pages/timestamps.md
+++ b/pages/timestamps.md
@@ -1,0 +1,82 @@
+
+
+# Zentail Open API Timestamp Formats
+
+This document outlines how to format a timestamp for communicating with our API. Timestamps are used in many calls including requests like [GET /inventory](https://developer.zentail.com/#/Inventory/get_inventory), [GET /salesOrder](https://developer.zentail.com/#/SalesOrder/get_salesOrder) and in many responses.
+
+The timestamp format conforms to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) and should look something like this:
+
+```
+2019-05-06T16:49:49.199Z
+```
+
+If we break this down you can see there are 2 main parts. The first is the date in `YYYY-MM-DD` format. Next is the letter `T` which is used to act as a separator between the date and time. After the `T` we have the time using the format `hh:mm:ss.v` (`v` is a number of milliseconds). The trailing `Z` indicates "zulu time" (a.k.a. GMT), there are more details below about specifying time zones.
+
+## Time Zones
+
+Time zones can be provided in a variety of ways. We recommend always providing a timezone string with your requests.
+
+### GMT
+
+If your timestamp is provided in GMT, you can simply include the `Z` at the end of the string:
+
+```
+2019-05-06T16:49:49.199Z
+```
+
+### Other Time Zones
+
+For any other time zone, you can include the offset in hh:mm format:
+
+```
+2018-03-02T14:58:03-05:00 		// GMT - 5 Hours
+```
+
+```
+2018-03-02T14:58:03+02:00		// GMT + 2 hours
+```
+
+## Examples
+
+Below are examples in a few different languages for outputting dates in the correct format.
+
+### PHP
+
+```php
+echo date("c");
+// 2019-05-06T13:21:45-04:00
+
+echo date("r", strtotime("2019-05-06T13:21:45-04:00"));
+// 'Mon, 06 May 2019 13:21:45 -0400'
+```
+
+### Python
+```python
+datetime.datetime.now().replace(tzinfo=datetime.timezone.utc).isoformat()
+# '2019-05-06T13:26:52.798153+00:00'
+```
+
+### Go
+```go
+fmt.Println(time.Now().Format(time.RFC3339))
+```
+
+### Bash
+```bash
+date -u +"%Y-%m-%dT%H:%M:%SZ"
+# 2019-05-06T17:25:17Z
+```
+
+For further reference, timestamps are currently validated against the following regular expression:
+
+```regex
+^(\\d+)-(0[1-9]|1[012])-(0[1-9]|[12]\\d|3[01])[Tt]([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d|60)(\\.\\d+)?(([Zz])|([\\+|\\-]([01]\\d|2[0-3]):([0-5]\\d)))$
+```
+
+## URL Encoding
+
+Keep in mind that since the timestamp format contains colons it may need to be url encoded when providing it in a request. For example:
+
+```
+curl -X GET "https://api.zentail.com/v1/salesOrder?lastUpdatedTs=2019-05-08T17%3A01%3A16.152Z" -H "accept: application/json" -H "AUTHORIZATION: <your token here>"
+```

--- a/pages/timestamps.md
+++ b/pages/timestamps.md
@@ -14,11 +14,11 @@ If we break this down you can see there are 2 main parts. The first is the date 
 
 ## Time Zones
 
-Time zones can be provided in a variety of ways. We recommend always providing a timezone string with your requests.
+Time zones can be provided in a variety of ways. It is recommended that request always contain a timezone.
 
 ### GMT
 
-If your timestamp is provided in GMT, you can simply include the `Z` at the end of the string:
+If the timezone is provided in GMT, just include the 'Z' at the end:
 
 ```
 2019-05-06T16:49:49.199Z
@@ -26,7 +26,7 @@ If your timestamp is provided in GMT, you can simply include the `Z` at the end 
 
 ### Other Time Zones
 
-For any other time zone, you can include the offset in hh:mm format:
+For any other time zone, include the offset in hh:mm format
 
 ```
 2018-03-02T14:58:03-05:00 		// GMT - 5 Hours

--- a/src/core/components/model-example.jsx
+++ b/src/core/components/model-example.jsx
@@ -39,10 +39,10 @@ export default class ModelExample extends React.Component {
     return <div>
       <ul className="tab">
         <li className={ "tabitem" + ( isExecute || this.state.activeTab === "example" ? " active" : "") }>
-          <a className="tablinks" data-name="example" onClick={ this.activeTab }>Example Value</a>
+          <a className="tablinks" data-name="example" onClick={ this.activeTab }>Example Request</a>
         </li>
         { schema ? <li className={ "tabitem" + ( !isExecute && this.state.activeTab === "model" ? " active" : "") }>
-          <a className={ "tablinks" + ( isExecute ? " inactive" : "" )} data-name="model" onClick={ this.activeTab }>Model</a>
+          <a className={ "tablinks" + ( isExecute ? " inactive" : "" )} data-name="model" onClick={ this.activeTab }>Field Explanations</a>
         </li> : null }
       </ul>
       <div>

--- a/src/plugins/topbar/topbar.jsx
+++ b/src/plugins/topbar/topbar.jsx
@@ -108,6 +108,8 @@ export default class Topbar extends React.Component {
               <span>Zentail Developer Portal</span>
             </Link>
             <ul className="links">
+              <li><a href="https://developer.zentail.com/">API Specification</a></li>
+              <li><a href="https://developer.zentail.com/pages/guides.html">API Guides</a></li>
               <li><a href="https://app.zentail.com/user/dashboard">Log In</a></li>
             </ul>
           </div>

--- a/src/style/_topbar.scss
+++ b/src/style/_topbar.scss
@@ -37,9 +37,11 @@
         top: -5px;
         list-style: none;
         font-size: 12px;
+        width: 400px;
 
         li {
             margin:15px;
+            float:left;
 
             a {
                 font-size:17px;

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -16,5 +16,13 @@
     @import 'errors';
     @include text_body();
     @import 'split-pane-mode';
-    @import '../../node_modules/highlight.js/styles/zenburn.css'
+    @import '../../node_modules/highlight.js/styles/zenburn.css';
+
+
+    li.tabitem a[data-name="example"],
+    li.tabitem a[data-name="model"] {
+        font-size: 24px;
+        text-decoration: underline;
+        margin-right:15px;
+    }
 }


### PR DESCRIPTION
Includes:

1. a "guides" page which links to 9 other docs.
2. adds the link to the spec, dashboard and guides to the header
3. adds docs for throttling, timestamps, paging, order syncing,
inventory integrations and 3pl integrations.

see: hdtradeservices/etp#10768
see: hdtradeservices/etp#9927

also includes:
Update styles on docs 
Makes the example and model sections much more noticeable